### PR TITLE
Feat-19: request processing and sending response measurements

### DIFF
--- a/app/actions/request.ts
+++ b/app/actions/request.ts
@@ -12,7 +12,7 @@ export async function handleRequest(form: z.infer<ReturnType<typeof Client>>) {
   const start = performance.now();
   const promise = fetch(form.url, requestObject);
   const result = await promise;
-  const timestamp = ((performance.now() - start) / 1000).toFixed(2);
+  const timestamp = +((performance.now() - start) / 1000).toFixed(2);
   if (!result.ok) {
     return {
       status: result.status,
@@ -20,20 +20,13 @@ export async function handleRequest(form: z.infer<ReturnType<typeof Client>>) {
     };
   }
   const responseSize = new TextEncoder().encode(JSON.stringify(result)).length;
-  const isJson =
-    result.headers.get('content-type')?.includes('application/json') || false;
-  if (!isJson) {
-    return {
-      statusText: 'Response is not in JSON format',
-    };
-  }
   console.log({
     date,
     requestSize,
     timestamp,
     responseSize,
   });
-  const data = await result.json();
+  const data = await result.text();
   return {
     status: result.status,
     statusText: result.statusText,

--- a/app/actions/request.ts
+++ b/app/actions/request.ts
@@ -3,18 +3,42 @@
 import { Client } from '@entities';
 import z from 'zod';
 
-export async function builder(form: z.infer<ReturnType<typeof Client>>) {
+export async function handleRequest(form: z.infer<ReturnType<typeof Client>>) {
+  const date = new Date(Date.now());
   const requestObject = bodyBuilder(form);
+  const requestSize = new TextEncoder().encode(
+    JSON.stringify(requestObject)
+  ).length;
+  const start = performance.now();
   const promise = fetch(form.url, requestObject);
   const result = await promise;
+  const timestamp = ((performance.now() - start) / 1000).toFixed(2);
   if (!result.ok) {
     return {
       status: result.status,
       statusText: result.statusText,
     };
   }
+  const responseSize = new TextEncoder().encode(JSON.stringify(result)).length;
+  const isJson =
+    result.headers.get('content-type')?.includes('application/json') || false;
+  if (!isJson) {
+    return {
+      statusText: 'Response is not in JSON format',
+    };
+  }
+  console.log({
+    date,
+    requestSize,
+    timestamp,
+    responseSize,
+  });
   const data = await result.json();
-  return data;
+  return {
+    status: result.status,
+    statusText: result.statusText,
+    data,
+  };
 }
 
 function bodyBuilder(form: z.infer<ReturnType<typeof Client>>) {

--- a/app/actions/request.ts
+++ b/app/actions/request.ts
@@ -35,21 +35,24 @@ export async function handleRequest(form: Form) {
 }
 
 function bodyBuilder(form: Form) {
-  const headers =
+  const filteredHeaders =
     form.headers?.length && form.headers[0].header
-      ? Object.fromEntries(
-          form.headers
-            .filter(({ header }) => !/[а-яА-ЯёЁ]/.test(header))
-            .map(({ header, value }) => [header, value])
-        )
+      ? form.headers
+          .filter(({ header, value }) => {
+            return !/[а-яА-ЯёЁ]/.test(header) && !/[а-яА-ЯёЁ]/.test(value);
+          })
+          .map(({ header, value }) => [header, value])
+      : [];
+  const headers =
+    filteredHeaders?.length > 0
+      ? Object.fromEntries(filteredHeaders)
       : undefined;
-
   const methodsWithBody = ['post', 'put', 'patch'];
   const canHaveBody = methodsWithBody.includes(form.method);
 
   return {
     method: form.method,
-    ...(headers && { headers }),
+    ...(headers ? { headers } : {}),
     ...(canHaveBody && { body: form.body }),
   };
 }

--- a/app/actions/request.ts
+++ b/app/actions/request.ts
@@ -3,7 +3,7 @@
 import { Client } from '@entities';
 import z from 'zod';
 
-export async function handleRequest(form: z.infer<ReturnType<typeof Client>>) {
+export async function handleRequest(form: Form) {
   const date = new Date(Date.now());
   const requestObject = bodyBuilder(form);
   const requestSize = new TextEncoder().encode(
@@ -12,7 +12,7 @@ export async function handleRequest(form: z.infer<ReturnType<typeof Client>>) {
   const start = performance.now();
   const promise = fetch(form.url, requestObject);
   const result = await promise;
-  const timestamp = +(performance.now() - start).toFixed(2);
+  const timestamp = Number(performance.now() - start).toFixed(2);
   if (!result.ok) {
     return {
       status: result.status,
@@ -34,37 +34,24 @@ export async function handleRequest(form: z.infer<ReturnType<typeof Client>>) {
   };
 }
 
-function bodyBuilder(form: z.infer<ReturnType<typeof Client>>) {
-  let headers;
-  if (form.headers?.length && form.headers?.[0].header) {
-    headers = Object.fromEntries(
-      form.headers.map((item) => [item.header, item.value])
-    );
-  }
+function bodyBuilder(form: Form) {
+  const headers =
+    form.headers?.length && form.headers[0].header
+      ? Object.fromEntries(
+          form.headers
+            .filter(({ header }) => !/[а-яА-ЯёЁ]/.test(header))
+            .map(({ header, value }) => [header, value])
+        )
+      : undefined;
 
-  let requestObject: RequestObject;
-  if (
-    (form.method === 'post' && headers) ||
-    (form.method === 'put' && headers) ||
-    (form.method === 'patch' && headers)
-  ) {
-    requestObject = { method: form.method, headers: headers, body: form.body };
-  } else if (
-    form.method === 'post' ||
-    form.method === 'put' ||
-    form.method === 'patch'
-  ) {
-    requestObject = { method: form.method, body: form.body };
-  } else if (headers) {
-    requestObject = { method: form.method, headers: headers };
-  } else {
-    requestObject = { method: form.method };
-  }
-  return requestObject;
+  const methodsWithBody = ['post', 'put', 'patch'];
+  const canHaveBody = methodsWithBody.includes(form.method);
+
+  return {
+    method: form.method,
+    ...(headers && { headers }),
+    ...(canHaveBody && { body: form.body }),
+  };
 }
 
-type RequestObject = {
-  method: string;
-  headers?: Record<string, string>;
-  body?: string | undefined;
-};
+type Form = z.infer<ReturnType<typeof Client>>;

--- a/app/actions/request.ts
+++ b/app/actions/request.ts
@@ -12,7 +12,7 @@ export async function handleRequest(form: z.infer<ReturnType<typeof Client>>) {
   const start = performance.now();
   const promise = fetch(form.url, requestObject);
   const result = await promise;
-  const timestamp = +((performance.now() - start) / 1000).toFixed(2);
+  const timestamp = +(performance.now() - start).toFixed(2);
   if (!result.ok) {
     return {
       status: result.status,
@@ -41,13 +41,19 @@ function bodyBuilder(form: z.infer<ReturnType<typeof Client>>) {
       form.headers.map((item) => [item.header, item.value])
     );
   }
+
   let requestObject: RequestObject;
   if (
     (form.method === 'post' && headers) ||
-    (form.method === 'put' && headers)
+    (form.method === 'put' && headers) ||
+    (form.method === 'patch' && headers)
   ) {
     requestObject = { method: form.method, headers: headers, body: form.body };
-  } else if (form.method === 'post' || form.method === 'put') {
+  } else if (
+    form.method === 'post' ||
+    form.method === 'put' ||
+    form.method === 'patch'
+  ) {
     requestObject = { method: form.method, body: form.body };
   } else if (headers) {
     requestObject = { method: form.method, headers: headers };

--- a/app/actions/request.ts
+++ b/app/actions/request.ts
@@ -1,0 +1,47 @@
+'use server';
+
+import { Client } from '@entities';
+import z from 'zod';
+
+export async function builder(form: z.infer<ReturnType<typeof Client>>) {
+  const requestObject = bodyBuilder(form);
+  const promise = fetch(form.url, requestObject);
+  const result = await promise;
+  if (!result.ok) {
+    return {
+      status: result.status,
+      statusText: result.statusText,
+    };
+  }
+  const data = await result.json();
+  return data;
+}
+
+function bodyBuilder(form: z.infer<ReturnType<typeof Client>>) {
+  let headers;
+  if (form.headers?.length && form.headers?.[0].header) {
+    headers = Object.fromEntries(
+      form.headers.map((item) => [item.header, item.value])
+    );
+  }
+  let requestObject: RequestObject;
+  if (
+    (form.method === 'post' && headers) ||
+    (form.method === 'put' && headers)
+  ) {
+    requestObject = { method: form.method, headers: headers, body: form.body };
+  } else if (form.method === 'post' || form.method === 'put') {
+    requestObject = { method: form.method, body: form.body };
+  } else if (headers) {
+    requestObject = { method: form.method, headers: headers };
+  } else {
+    requestObject = { method: form.method };
+  }
+  return requestObject;
+}
+
+type RequestObject = {
+  method: string;
+  headers?: Record<string, string>;
+  body?: string | undefined;
+};

--- a/src/components/auth/signInForm.tsx
+++ b/src/components/auth/signInForm.tsx
@@ -68,7 +68,7 @@ export function SignInForm() {
             disabled={isLoading}
           />
           {errors.email && (
-            <p className="text-sm text-red-500 absolute -bottom-7 left-1">
+            <p className="text-sm text-red-500 absolute -bottom-10 left-1">
               {errors.email.message}
             </p>
           )}
@@ -84,7 +84,7 @@ export function SignInForm() {
             disabled={isLoading}
           />
           {errors.password && (
-            <p className="text-sm text-red-500 absolute -bottom-7 left-1">
+            <p className="text-sm text-red-500 absolute -bottom-10 left-1">
               {errors.password.message}
             </p>
           )}

--- a/src/components/auth/signUpForm.tsx
+++ b/src/components/auth/signUpForm.tsx
@@ -77,7 +77,7 @@ export function SignUpForm() {
             disabled={isLoading}
           />
           {errors.email && (
-            <p className="absolute -bottom-7 left-1 text-sm text-red-500">
+            <p className="absolute -bottom-10 left-1 text-sm text-red-500">
               {errors.email.message}
             </p>
           )}
@@ -93,7 +93,7 @@ export function SignUpForm() {
             disabled={isLoading}
           />
           {errors.password && (
-            <p className="text-sm absolute -bottom-7 left-1 text-red-500">
+            <p className="text-sm absolute -bottom-10 left-1 text-red-500">
               {errors.password.message}
             </p>
           )}

--- a/src/components/request.tsx
+++ b/src/components/request.tsx
@@ -27,7 +27,7 @@ import { Client } from '@entities';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import z from 'zod';
-import { builder } from '../../app/actions/request';
+import { handleRequest } from '../../app/actions/request';
 
 const methods = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options'];
 
@@ -56,7 +56,7 @@ export const Request = () => {
         <form
           onSubmit={form.handleSubmit(() => {
             const formValues: Client = form.getValues();
-            console.log(builder(formValues));
+            handleRequest(formValues);
           })}
           className="flex flex-col gap-1"
         >

--- a/src/components/request.tsx
+++ b/src/components/request.tsx
@@ -27,6 +27,7 @@ import { Client } from '@entities';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import z from 'zod';
+import { builder } from '../../app/actions/request';
 
 const methods = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options'];
 
@@ -54,7 +55,8 @@ export const Request = () => {
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(() => {
-            console.log(form.getValues());
+            const formValues: Client = form.getValues();
+            console.log(builder(formValues));
           })}
           className="flex flex-col gap-1"
         >

--- a/src/entities/schemas/client.ts
+++ b/src/entities/schemas/client.ts
@@ -18,8 +18,8 @@ export const Client = (t: (arg: string) => string) =>
       headers: z
         .array(
           z.object({
-            header: z.string().optional(),
-            value: z.string().optional(),
+            header: z.string(),
+            value: z.string(),
           })
         )
         .optional(),


### PR DESCRIPTION
**✅ Description**

- [x] Processing request
- [x] Validate request
- [x] Send request 
- [x] Request measurements
- [x] Fixed a bug with the error text overflowing on input
- [x] Removed optional from headers=>header/value in zod schema

**🔍 Checklist**

- [x] Self-reviewed the code
- [x] No @ts-ignore
- [x] No console errors and warnings
- [ ] No execution results console.log
- [x] No commented code sections
- [ ] Internationalization is supported
- [ ] New dependencies

Internalization нужно будет внедрять на UI, ибо это серверная функция
Есть console.log потому что timestamp, size, date негде иначе хранить
